### PR TITLE
Fixed Kodi button mapping

### DIFF
--- a/configgen/generators/kodi/kodiConfig.py
+++ b/configgen/generators/kodi/kodiConfig.py
@@ -14,7 +14,7 @@ def writeKodiConfigs(currentControllers):
 
     kodimapping = {
         # buttons
-        "a": "y", "b": "a", "x": "b", "y": "x",
+        "a": "b", "b": "a", "x": "y", "y": "x",
         "hotkey": "guide", "select": "back", "start": "start",
         "pageup": "leftbumper", "l2": "lefttrigger", "pagedown": "rightbumper", "r2": "righttrigger",
 


### PR DESCRIPTION
https://batocera-linux.xorhub.com/forum/d/483-kodi-gamepad-reverts-to-default-mapping/41

There's something wrong with the button mapping. I suppose this file should map SNES buttons to X360 buttons. In that case, this line should be : 

```python
"a": "b", "b": "a", "x": "y", "y": "x",
```

With this modification, I get proper button mapping.
