### PR TITLE
amiga / fsuae: support multi disks inside one zip...

### DIFF
--- a/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/configgen/generators/fsuae/fsuaeGenerator.py
@@ -59,8 +59,8 @@ class FsuaeGenerator(Generator):
         if system.config['core'] in ["CD32", "CDTV"]:
             device_type = "cdrom"
 
-        # extract zip here (according to readme.txt in this folder, this is the right place)
-        TEMP_DIR="/recalbox/share/extractions/amiga/" # with trailing slash!
+        # extract zip here
+        TEMP_DIR="/tmp/fsuae/" # with trailing slash!
         diskNames = []
 
         # read from zip


### PR DESCRIPTION
... by temporary extraction.
fsuae has *no* other possibility :|

see discussion 
https://batocera-linux.xorhub.com/forum/d/938-amiga-multi-disk-can-t-change-disk/2
If you have TOSEC or no-intro sets, everything is in a single zip.
(TODO: check amiberry)

using /recalbox/share/extractions/amiga as temp directory.
according to lisez-moi.txt file, this should be used.
(alternative /tmp ?)
will be erased on every start (but not on end - dunno where to hook)
(barely seen a game with 10+ disks, so no more than 8MB will be used)